### PR TITLE
allow to select multiple communities in materials(). fixes #1

### DIFF
--- a/R/materials.R
+++ b/R/materials.R
@@ -9,8 +9,8 @@
 #' @export
 materials <- function (community = c("HijiyamaR", "Hiroshima.R", "Kashiwa.R", "Nagoya.R", "Osaka.R", "SappoRo.R", "Tokyo.R", "Tsukuba.R", "Yokohama.R"), 
                       number = NULL, session = NULL, browse = FALSE) {
-  community <- match.arg(community)
-  res <- filter(JRSlide, Community == community)
+  community <- match.arg(community, several.ok = TRUE)
+  res <- filter(JRSlide, Community %in% community)
    if (!is.null(number)) { # If when number is NULL else NULL
      if (!is.null(session)) {
        if (browse == FALSE) {


### PR DESCRIPTION
Thanks for this great work as usual!

I found `materials()` still doesn't return all materials.

The reason seems that `match.arg()` returns only the first matched one by default, so we have to specify `several.ok = TRUE` explicitly.
